### PR TITLE
Configure vite to generate relative links

### DIFF
--- a/parent-vite.config.js
+++ b/parent-vite.config.js
@@ -10,6 +10,10 @@ import manifestJSON from "./target/manifest.json";
 
 const cssLink = manifestJSON["index.html"]["css"][0];
 module.exports = defineConfig({
+    // The default base is "/", which results in absolute links being generated, e.g. /assets/foo.js.
+    // However, we want to be able to serve chatterbox from a directory which isn't the server's root.
+    // By setting base to an empty string, relative links are generated, e.g. assets/foo.js.
+    base: "",
     build: {
         rollupOptions: {
             input: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,6 +12,11 @@ module.exports = defineConfig(({ command }) => {
     } else {
         return {
             // build specific config
+
+            // The default base is "/", which results in absolute links being generated, e.g. /assets/foo.js.
+            // However, we want to be able to serve chatterbox from a directory which isn't the server's root.
+            // By setting base to an empty string, relative links are generated, e.g. assets/foo.js.
+            base: "",
             build: {
                 rollupOptions: {
                     input: {


### PR DESCRIPTION
Right now, vite generates absolute links to assets, e.g. `/assets/foo.js`. For this reason, chatterbox can only be served from the webserver root, e.g. `https://example.com/`, as assets are expected to be available there, i.e. `https://example.com/assets/foo.js`.

Instead, vite can be configured to generate relative links, i.e. `assets/foo.js`. In this case, the links are relative to the directory where `index.html` is located. This would cover both the case of serving from the webserver root and a subdirectory.

This PR changes the vite config so that generated links are relative to `index.html`.